### PR TITLE
Retain hardened runtime when copying helper

### DIFF
--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -9,7 +9,7 @@ mkdir -p "$helper_dir"
 cp -rf "$origin_helper_path" "$helper_dir/"
 
 defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
-codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 
 if [[ $CONFIGURATION == "Release" ]]; then
 	rm -rf "$origin_helper_path"


### PR DESCRIPTION
Adds `-o runtime` to the `codesign` step when copying the helper.