### PR TITLE
Make script paths absolute

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,13 +42,13 @@ Add a new ["Run Script Phase"](http://stackoverflow.com/a/39633955/64949) below 
 Carthage:
 
 ```sh
-./Carthage/Build/Mac/LaunchAtLogin.framework/Resources/copy-helper.sh
+${PROJECT_DIR}/Carthage/Build/Mac/LaunchAtLogin.framework/Resources/copy-helper.sh
 ```
 
 CocoaPods:
 
 ```sh
-./Pods/LaunchAtLogin/LaunchAtLogin/copy-helper.sh
+${PROJECT_DIR}/Pods/LaunchAtLogin/LaunchAtLogin/copy-helper.sh
 ```
 
 Use it in your app:

--- a/readme.md
+++ b/readme.md
@@ -42,13 +42,13 @@ Add a new ["Run Script Phase"](http://stackoverflow.com/a/39633955/64949) below 
 Carthage:
 
 ```sh
-${PROJECT_DIR}/Carthage/Build/Mac/LaunchAtLogin.framework/Resources/copy-helper.sh
+"${PROJECT_DIR}/Carthage/Build/Mac/LaunchAtLogin.framework/Resources/copy-helper.sh"
 ```
 
 CocoaPods:
 
 ```sh
-${PROJECT_DIR}/Pods/LaunchAtLogin/LaunchAtLogin/copy-helper.sh
+"${PROJECT_DIR}/Pods/LaunchAtLogin/LaunchAtLogin/copy-helper.sh"
 ```
 
 Use it in your app:


### PR DESCRIPTION
I propose to change `./Carthage/...` to `${PROJECT_DIR}/Carthage/...` so you end up with an absolute path. This should be more robust when users have weird project settings.