### PR TITLE
Support non-sandboxed apps

### DIFF
--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -10,14 +10,14 @@ cp -rf "$origin_helper_path" "$helper_dir/"
 
 defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
-if [[ -z ${CODE_SIGN_ENTITLEMENTS} ]];
+if [[ -n ${CODE_SIGN_ENTITLEMENTS} ]];
 then
-    codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
-else
     codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+else
+    codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
 if [[ $CONFIGURATION == "Release" ]]; then
-	rm -rf "$origin_helper_path"
-	rm "$(dirname "$origin_helper_path")/copy-helper.sh"
+    rm -rf "$origin_helper_path"
+    rm "$(dirname "$origin_helper_path")/copy-helper.sh"
 fi

--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -12,9 +12,9 @@ defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT
 
 if [[ -z ${CODE_SIGN_ENTITLEMENTS} ]];
 then
-    codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
-else
     codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+else
+    codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
 if [[ $CONFIGURATION == "Release" ]]; then

--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -10,14 +10,13 @@ cp -rf "$origin_helper_path" "$helper_dir/"
 
 defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
-if [[ -n ${CODE_SIGN_ENTITLEMENTS} ]];
-then
-    codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
+	codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 else
-    codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+	codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
 if [[ $CONFIGURATION == "Release" ]]; then
-    rm -rf "$origin_helper_path"
-    rm "$(dirname "$origin_helper_path")/copy-helper.sh"
+	rm -rf "$origin_helper_path"
+	rm "$(dirname "$origin_helper_path")/copy-helper.sh"
 fi

--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -9,7 +9,13 @@ mkdir -p "$helper_dir"
 cp -rf "$origin_helper_path" "$helper_dir/"
 
 defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
-codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+
+if [[ -z ${CODE_SIGN_ENTITLEMENTS} ]];
+then
+    codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+else
+    codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+fi
 
 if [[ $CONFIGURATION == "Release" ]]; then
 	rm -rf "$origin_helper_path"


### PR DESCRIPTION
I have a legacy app that doesn't yet support the App Sandbox. Without the Sandbox, the parameter will be `--entitlements=""`, resulting in a segmentation fault.

This change allows both kinds of project settings to work.