### PR TITLE
Extend NSMenu with launchAtLoginItem(), addLaunchAtLoginItem()

### DIFF
--- a/LaunchAtLogin.xcodeproj/project.pbxproj
+++ b/LaunchAtLogin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0ABB8382236B607100E2FEAD /* NSMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABB8381236B607100E2FEAD /* NSMenu.swift */; };
 		E32E9B681EB87D7B000FEEE9 /* LaunchAtLogin.h in Headers */ = {isa = PBXBuildFile; fileRef = E32E9B661EB87D7B000FEEE9 /* LaunchAtLogin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E32E9B6F1EB87DC5000FEEE9 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32E9B6E1EB87DC5000FEEE9 /* LaunchAtLogin.swift */; };
 		E32E9B771EB87EA3000FEEE9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32E9B761EB87EA3000FEEE9 /* main.swift */; };
@@ -25,6 +26,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0ABB8381236B607100E2FEAD /* NSMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSMenu.swift; sourceTree = "<group>"; };
 		E32E9B631EB87D7B000FEEE9 /* LaunchAtLogin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LaunchAtLogin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E32E9B661EB87D7B000FEEE9 /* LaunchAtLogin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = LaunchAtLogin.h; sourceTree = "<group>"; usesTabs = 1; };
 		E32E9B671EB87D7B000FEEE9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 				E32E9B661EB87D7B000FEEE9 /* LaunchAtLogin.h */,
 				E32E9B921EB889AE000FEEE9 /* copy-helper.sh */,
 				E32E9B671EB87D7B000FEEE9 /* Info.plist */,
+				0ABB8381236B607100E2FEAD /* NSMenu.swift */,
 			);
 			path = LaunchAtLogin;
 			sourceTree = "<group>";
@@ -216,6 +219,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E32E9B6F1EB87DC5000FEEE9 /* LaunchAtLogin.swift in Sources */,
+				0ABB8382236B607100E2FEAD /* NSMenu.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LaunchAtLogin/NSMenu.swift
+++ b/LaunchAtLogin/NSMenu.swift
@@ -1,0 +1,27 @@
+import Cocoa
+
+public extension NSMenu {
+	private class LaunchAtLoginMenuItem: NSMenuItem {
+		convenience init() {
+			self.init(
+				title: "Launch at Login",
+				action: #selector(toggleLaunchAtLogin(_:)),
+				keyEquivalent: ""
+			)
+
+			state = LaunchAtLogin.isEnabled ? .on : .off
+		}
+
+		@objc func toggleLaunchAtLogin(_: NSMenuItem) {
+			LaunchAtLogin.isEnabled = !LaunchAtLogin.isEnabled
+		}
+	}
+
+	func launchAtLoginItem() -> NSMenuItem {
+		return LaunchAtLoginMenuItem()
+	}
+
+	func addLaunchAtLoginItem() {
+		self.addItem(LaunchAtLoginMenuItem())
+	}
+}


### PR DESCRIPTION
In reference to #27, specifically:
> Not SwiftUI related, but relevant still: NSMenu#launchAtLoginItem() that returns a NSMenuItem that toggles LaunchAtLogin.isEnabled when checked, uses the correct checked state, and also comes with the default text of "Launch at Login" (note it's title-cased). And a NSMenu#addLaunchAtLoginItem() convenience method.