### PR TITLE
script should handle archives as well as regular builds

### DIFF
--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-if [ "${DEPLOYMENT_LOCATION}" = "YES" ] ; then
-    WHERE="${DSTROOT}"
-    helper_dir="${WHERE}/$CONTENTS_FOLDER_PATH/Library/LoginItems"
-    origin_helper_path="${helper_dir}/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
+if [ "${DEPLOYMENT_LOCATION}" = "YES" ]; then # this is an archive/Profile build
+	build_root="${DSTROOT}"
+	helper_dir="${build_root}/$CONTENTS_FOLDER_PATH/Library/LoginItems"
+	origin_helper_path="${helper_dir}/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
 else
-    WHERE="${BUILT_PRODUCTS_DIR}"
-    origin_helper_path="${WHERE}/$FRAMEWORKS_FOLDER_PATH/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
-    helper_dir="${WHERE}/$CONTENTS_FOLDER_PATH/Library/LoginItems"
+	build_root="${BUILT_PRODUCTS_DIR}"
+	helper_dir="${build_root}/$CONTENTS_FOLDER_PATH/Library/LoginItems"
+	origin_helper_path="${build_root}/$FRAMEWORKS_FOLDER_PATH/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
 fi
 
 helper_path="$helper_dir/LaunchAtLoginHelper.app"

--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-origin_helper_path="$BUILT_PRODUCTS_DIR/$FRAMEWORKS_FOLDER_PATH/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
-helper_dir="$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Library/LoginItems"
+if [ "${DEPLOYMENT_LOCATION}" = "YES" ] ; then
+    WHERE="${DSTROOT}"
+    helper_dir="${WHERE}/$CONTENTS_FOLDER_PATH/Library/LoginItems"
+    origin_helper_path="${helper_dir}/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
+else
+    WHERE="${BUILT_PRODUCTS_DIR}"
+    origin_helper_path="${WHERE}/$FRAMEWORKS_FOLDER_PATH/LaunchAtLogin.framework/Resources/LaunchAtLoginHelper.app"
+    helper_dir="${WHERE}/$CONTENTS_FOLDER_PATH/Library/LoginItems"
+fi
+
 helper_path="$helper_dir/LaunchAtLoginHelper.app"
 
 rm -rf "$helper_path"
@@ -18,5 +26,5 @@ fi
 
 if [[ $CONFIGURATION == "Release" ]]; then
 	rm -rf "$origin_helper_path"
-	rm "$(dirname "$origin_helper_path")/copy-helper.sh"
+	rm "$(dirname "$origin_helper_path")/copy-helper.sh" || true
 fi


### PR DESCRIPTION
Fixes #7 by (a) deleting `LaunchAtLogin.app` from the correct location during Archive/Profiling builds, which differs from where it's during Debug/Run builds.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#7: copy-helper.sh script "No such file or directory" when profiling](https://issuehunt.io/repos/98812730/issues/7)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->