### PR TITLE
Don’t inherit entitlements from the app

### DIFF
--- a/LaunchAtLogin/LaunchAtLogin.entitlements
+++ b/LaunchAtLogin/LaunchAtLogin.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/LaunchAtLogin/copy-helper.sh
+++ b/LaunchAtLogin/copy-helper.sh
@@ -11,7 +11,7 @@ cp -rf "$origin_helper_path" "$helper_dir/"
 defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
 if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
-	codesign --force --entitlements="$CODE_SIGN_ENTITLEMENTS" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+	codesign --force --entitlements="$(dirname "$origin_helper_path")/LaunchAtLogin.entitlements" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 else
 	codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
@@ -19,4 +19,5 @@ fi
 if [[ $CONFIGURATION == "Release" ]]; then
 	rm -rf "$origin_helper_path"
 	rm "$(dirname "$origin_helper_path")/copy-helper.sh"
+	rm "$(dirname "$origin_helper_path")/LaunchAtLogin.entitlements"
 fi


### PR DESCRIPTION
The launcher app only needs to be sandboxed. It doesn’t need any of the other entitlements of the main app.