### PR TITLE
Fix building on Apple Silicon

### DIFF
--- a/LaunchAtLogin.xcodeproj/project.pbxproj
+++ b/LaunchAtLogin.xcodeproj/project.pbxproj
@@ -300,7 +300,6 @@
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -356,7 +355,6 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
-				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
LaunchAtLogin can build for any architecture, no need to specify what's valid.