### PR TITLE
Make LaunchAtLogin get correctly notarized by Apple when building with configurations named other than `Release`

### DIFF
--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -44,6 +44,6 @@ else
 	codesign --force --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
-if [[ $CONFIGURATION == "Release" ]]; then
+if [[ $CONFIGURATION != "Debug" ]]; then
 	rm -rf "$contents_path/Resources/LaunchAtLogin_LaunchAtLogin.bundle"
 fi

--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -39,9 +39,9 @@ unzip "$helper_path" -d "$login_items/"
 defaults write "$login_helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
 if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
-	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
+	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
 else
-	codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+	codesign --force --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
 if [[ $CONFIGURATION == "Release" ]]; then

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,10 @@ CocoaPods used to be supported, but [it did not work well](https://github.com/si
 
 Apple deprecated that API without providing an alternative. Apple engineers have [stated that it's still the preferred API to use](https://github.com/alexzielenski/StartAtLoginController/issues/12#issuecomment-307525807). I plan to use it as long as it's available. There are workarounds I can implement if Apple ever removes the API, so rest assured, this module will be made to work even then. If you want to see this resolved, submit a [Feedback Assistant](https://feedbackassistant.apple.com) report with [the following text](https://github.com/feedback-assistant/reports/issues/16). There's unfortunately still [no way to suppress warnings in Swift](https://stackoverflow.com/a/32861678/64949).
 
+#### I can't see the `LaunchAtLogin.bundle` in my debug release
+
+This framework makes the assumption that your debug configuration is named `Debug`. If you are ussing different configuration names, like `Debug-MAS`, the `LaunchAtLogin_LaunchAtLogin.bundle` will get deleted at build time, as if it was a production-like release, as discussed [here](https://github.com/sindresorhus/LaunchAtLogin/issues/50).
+
 ## Related
 
 - [Defaults](https://github.com/sindresorhus/Defaults) - Swifty and modern UserDefaults


### PR DESCRIPTION
`LaunchAtLogin` made the assumption that production releases were built using a configuration named `Release`, but it's often helpful to use other configuration names, like `Release-MAS`. This prevented the copy helper script from removing the `LaunchAtLogin_LaunchAtLogin.bundle` on such releases, making the notarization process fail.

Made the script remove the bundle on all builds except those using a configuration named explicitly `Debug` and added the new assumption to the Readme FAQ.

This should fix #50.