### PR TITLE
Fix notarization issues with build configs not named "Release"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xcuserdata
 project.xcworkspace
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 xcuserdata
 project.xcworkspace
-.DS_Store

--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -44,6 +44,6 @@ else
 	codesign --force --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
-if [[ $CONFIGURATION == "Release" ]]; then
+if [[ $CONFIGURATION != "Debug" ]]; then
 	rm -rf "$contents_path/Resources/LaunchAtLogin_LaunchAtLogin.bundle"
 fi

--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -39,9 +39,9 @@ unzip "$helper_path" -d "$login_items/"
 defaults write "$login_helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
 if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
-	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
+	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
 else
-	codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+	codesign --force --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
 if [[ $CONFIGURATION == "Release" ]]; then

--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -44,7 +44,7 @@ else
 	codesign --force --deep --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
-# If this is being built for multiple architectures, assume it is a release build and we should clean up
+# If this is being built for multiple architectures, assume it is a release build and we should clean up.
 if [[ $ONLY_ACTIVE_ARCH == "NO" ]]; then
 	rm -rf "$contents_path/Resources/LaunchAtLogin_LaunchAtLogin.bundle"
 fi

--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -39,11 +39,12 @@ unzip "$helper_path" -d "$login_items/"
 defaults write "$login_helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
 if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
-	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
+	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --deep --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
 else
-	codesign --force --deep -o runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
+	codesign --force --deep --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
-if [[ $CONFIGURATION != "Debug" ]]; then
+# If this is being built for multiple architectures, assume it is a release build and we should clean up
+if [[ $ONLY_ACTIVE_ARCH == "NO" ]]; then
 	rm -rf "$contents_path/Resources/LaunchAtLogin_LaunchAtLogin.bundle"
 fi

--- a/Sources/LaunchAtLogin/copy-helper.sh
+++ b/Sources/LaunchAtLogin/copy-helper.sh
@@ -16,7 +16,8 @@ else
 	codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
-if [[ $CONFIGURATION == "Release" ]]; then
+# If this is being built for multiple architectures, assume it is a release build and we should clean up
+if [[ $ONLY_ACTIVE_ARCH == "NO" ]]; then
 	rm -rf "$origin_helper_path"
 	rm "$(dirname "$origin_helper_path")/copy-helper.sh"
 	rm "$(dirname "$origin_helper_path")/LaunchAtLogin.entitlements"

--- a/Sources/LaunchAtLogin/copy-helper.sh
+++ b/Sources/LaunchAtLogin/copy-helper.sh
@@ -16,7 +16,7 @@ else
 	codesign --force --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
 fi
 
-# If this is being built for multiple architectures, assume it is a release build and we should clean up
+# If this is being built for multiple architectures, assume it is a release build and we should clean up.
 if [[ $ONLY_ACTIVE_ARCH == "NO" ]]; then
 	rm -rf "$origin_helper_path"
 	rm "$(dirname "$origin_helper_path")/copy-helper.sh"

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,10 @@ CocoaPods used to be supported, but [it did not work well](https://github.com/si
 
 Apple deprecated that API without providing an alternative. Apple engineers have [stated that it's still the preferred API to use](https://github.com/alexzielenski/StartAtLoginController/issues/12#issuecomment-307525807). I plan to use it as long as it's available. There are workarounds I can implement if Apple ever removes the API, so rest assured, this module will be made to work even then. If you want to see this resolved, submit a [Feedback Assistant](https://feedbackassistant.apple.com) report with [the following text](https://github.com/feedback-assistant/reports/issues/16). There's unfortunately still [no way to suppress warnings in Swift](https://stackoverflow.com/a/32861678/64949).
 
+#### I can't see the `LaunchAtLogin.bundle` in my debug release
+
+This framework makes the assumption that your debug configuration is named `Debug`. If you are ussing different configuration names, like `Debug-MAS`, the `LaunchAtLogin_LaunchAtLogin.bundle` will get deleted at build time, as if it was a production-like release, as discussed [here](https://github.com/sindresorhus/LaunchAtLogin/issues/50).
+
 ## Related
 
 - [Defaults](https://github.com/sindresorhus/Defaults) - Swifty and modern UserDefaults

--- a/readme.md
+++ b/readme.md
@@ -192,11 +192,11 @@ CocoaPods used to be supported, but [it did not work well](https://github.com/si
 
 Apple deprecated that API without providing an alternative. Apple engineers have [stated that it's still the preferred API to use](https://github.com/alexzielenski/StartAtLoginController/issues/12#issuecomment-307525807). I plan to use it as long as it's available. There are workarounds I can implement if Apple ever removes the API, so rest assured, this module will be made to work even then. If you want to see this resolved, submit a [Feedback Assistant](https://feedbackassistant.apple.com) report with [the following text](https://github.com/feedback-assistant/reports/issues/16). There's unfortunately still [no way to suppress warnings in Swift](https://stackoverflow.com/a/32861678/64949).
 
-#### I can't see the `LaunchAtLogin.bundle` in my debug release or I get a notarization error for developer ID distribution
+#### I can't see the `LaunchAtLogin.bundle` in my debug build or I get a notarization error for developer ID distribution
 
-As discussed [here](https://github.com/sindresorhus/LaunchAtLogin/issues/50), this framework tries to determine if you're making a release or debug build and clean up its install accordingly. If your debug build is missing the bundle or, conversely, your release build has the bundle and it causes a code signing error, that means this has failed.
+As discussed [here](https://github.com/sindresorhus/LaunchAtLogin/issues/50), this package tries to determine if you're making a release or debug build and clean up its install accordingly. If your debug build is missing the bundle or, conversely, your release build has the bundle and it causes a code signing error, that means this has failed.
 
-The script's determination is based on the "Build Active Architecture Only" flag in build settings. If this is set to YES, then the script will package LaunchAtLogin for a debug build. You must set this flag to NO if you plan on distributing the build with codesigning.
+The script's determination is based on the “Build Active Architecture Only” flag in build settings. If this is set to `YES`, then the script will package LaunchAtLogin for a debug build. You must set this flag to `NO` if you plan on distributing the build with codesigning.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -192,9 +192,11 @@ CocoaPods used to be supported, but [it did not work well](https://github.com/si
 
 Apple deprecated that API without providing an alternative. Apple engineers have [stated that it's still the preferred API to use](https://github.com/alexzielenski/StartAtLoginController/issues/12#issuecomment-307525807). I plan to use it as long as it's available. There are workarounds I can implement if Apple ever removes the API, so rest assured, this module will be made to work even then. If you want to see this resolved, submit a [Feedback Assistant](https://feedbackassistant.apple.com) report with [the following text](https://github.com/feedback-assistant/reports/issues/16). There's unfortunately still [no way to suppress warnings in Swift](https://stackoverflow.com/a/32861678/64949).
 
-#### I can't see the `LaunchAtLogin.bundle` in my debug release
+#### I can't see the `LaunchAtLogin.bundle` in my debug release or I get a notarization error for developer ID distribution
 
-This framework makes the assumption that your debug configuration is named `Debug`. If you are ussing different configuration names, like `Debug-MAS`, the `LaunchAtLogin_LaunchAtLogin.bundle` will get deleted at build time, as if it was a production-like release, as discussed [here](https://github.com/sindresorhus/LaunchAtLogin/issues/50).
+As discussed [here](https://github.com/sindresorhus/LaunchAtLogin/issues/50), this framework tries to determine if you're making a release or debug build and clean up its install accordingly. If your debug build is missing the bundle or, conversely, your release build has the bundle and it causes a code signing error, that means this has failed.
+
+The script's determination is based on the "Build Active Architecture Only" flag in build settings. If this is set to YES, then the script will package LaunchAtLogin for a debug build. You must set this flag to NO if you plan on distributing the build with codesigning.
 
 ## Related
 


### PR DESCRIPTION
Resolves #50 based on the excellent foundation from @rameerez in #52.

Changes compared to #52:
- Moves to using the "Build Active Architecture Only" build setting to determine a debug vs release build
- Updates documentation accordingly
- Reverts `codesign` command to use `--options` rather than `-o` as requested