### PR TITLE
Add ability to override the bundle id of launched app or login item

### DIFF
--- a/Sources/LaunchAtLogin/LaunchAtLogin.swift
+++ b/Sources/LaunchAtLogin/LaunchAtLogin.swift
@@ -13,7 +13,7 @@ public enum LaunchAtLogin {
 	@available(macOS 10.15, *)
 	public static let publisher = _publisher.eraseToAnyPublisher()
 
-	private static let id = "\(Bundle.main.bundleIdentifier!)-LaunchAtLoginHelper"
+	private static let id = Bundle.main.object(forInfoDictionaryKey: "LLTargetBundleId") as? String ?? "\(Bundle.main.bundleIdentifier!)-LaunchAtLoginHelper"
 
 	public static var isEnabled: Bool {
 		get {

--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -36,7 +36,16 @@ fi
 
 unzip "$helper_path" -d "$login_items/"
 
-defaults write "$login_helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
+plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
+bundle_override=$(/usr/libexec/PlistBuddy -c 'Print LLTargetBundleId' "${plist}")
+
+if [ ! -z "$bundle_override" -a "$bundle_override" != " " ]; then
+	bundle_identifier="$bundle_override"
+else
+	bundle_identifier="$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
+fi
+
+defaults write "$login_helper_path/Contents/Info" CFBundleIdentifier -string "$bundle_identifier"
 
 if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
 	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --deep --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"

--- a/Sources/LaunchAtLogin/copy-helper.sh
+++ b/Sources/LaunchAtLogin/copy-helper.sh
@@ -8,7 +8,16 @@ rm -rf "$helper_path"
 mkdir -p "$helper_dir"
 cp -rf "$origin_helper_path" "$helper_dir/"
 
-defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
+plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
+bundle_override=$(/usr/libexec/PlistBuddy -c 'Print LLTargetBundleId' "${plist}")
+
+if [ ! -z "$bundle_override" -a "$bundle_override" != " " ]; then
+	bundle_identifier="$bundle_override"
+else
+	bundle_identifier="$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
+fi
+
+defaults write "$helper_path/Contents/Info" CFBundleIdentifier -string "$bundle_identifier"
 
 if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
 	codesign --force --entitlements="$(dirname "$origin_helper_path")/LaunchAtLogin.entitlements" --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"

--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,14 @@ final class ViewController: NSViewController {
 
 <img src="storyboard-binding.png" width="445">
 
+#### Override bundle id of launched application
+
+By default the bundle id of the application that uses the helper will be used but you can override it by setting the `LLTargetBundleId` in Info.plist to the bundle id of the application that should be set as launch target.
+
+Make sure that the bundle id ends with `-LaunchAtLoginHelper` if you still would like to use the helper application in this library.
+
+If you point to a completely custom launch application and just use the api that this library provides, you can omit the "Run Script" phase.
+
 ## How does it work?
 
 The package bundles the helper app needed to launch your app and copies it into your app at build time.


### PR DESCRIPTION
Hello! 👋🏻 

This is a suggestion on how to enable further customization of the project setup to cover more advanced use-cases.
Essentially this PR will enable setting the bundle id that is set as login item by configuring a `LLTargetBundleId` post in Info.plist.

This can be utilized in a number of ways:
- This will allow the use of the api from outside the bundle that contains the login item, for example there could be a main application that contains another application that should be the one automatically started.
- This also allows skipping the use of the helper app altogether and pointing to a custom login application but still makes use of the api for toggling the application.