### PR TITLE
More robust ONLY_ACTIVE_ARCH comparison

### DIFF
--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -45,6 +45,6 @@ else
 fi
 
 # If this is being built for multiple architectures, assume it is a release build and we should clean up.
-if [[ $ONLY_ACTIVE_ARCH == "NO" ]]; then
+if [[ $ONLY_ACTIVE_ARCH != "YES" ]]; then
 	rm -rf "$contents_path/Resources/LaunchAtLogin_LaunchAtLogin.bundle"
 fi

--- a/Sources/LaunchAtLogin/copy-helper.sh
+++ b/Sources/LaunchAtLogin/copy-helper.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # If this is being built for multiple architectures, assume it is a release build and we should clean up.
-if [[ $ONLY_ACTIVE_ARCH == "NO" ]]; then
+if [[ $ONLY_ACTIVE_ARCH != "YES" ]]; then
 	rm -rf "$origin_helper_path"
 	rm "$(dirname "$origin_helper_path")/copy-helper.sh"
 	rm "$(dirname "$origin_helper_path")/LaunchAtLogin.entitlements"


### PR DESCRIPTION
The help for the `ONLY_ACTIVE_ARCH` value says:

> If enabled, only the active architecture is built. This setting will be ignored when building with a run destination which does not define a specific architecture, such as a 'Generic Device' run destination.

In other words, the compiler only checks for a value of `YES`; any other value seems to be sufficient to be interpreted as "no: build all architectures".

Therefore, someone who "resets" the value to the default using `ONLY_ACTIVE_ARCH =` in an xcconfig would result in building all architectures, but still have the helper bundle present in their final build app, which would cause problems with Apple's notarization process.

This change alters the build scripts slightly to remove the helper bundle if it's anything other than `YES`.